### PR TITLE
Add toggleable secure/vulnerable login with SQL Injection demo

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, request, render_template, redirect, url_for, flash
 from flask_sqlalchemy import SQLAlchemy
 import os
+from sqlalchemy import text
 
 app = Flask(__name__, 
             template_folder='frontend/pages', 

--- a/vulnerabilities/sql_injection_plan.md
+++ b/vulnerabilities/sql_injection_plan.md
@@ -1,0 +1,23 @@
+# SQL Injection Vulnerability Plan
+
+## Goal
+Create a login system with two versions:
+- A vulnerable version that can be tricked using SQL injection
+- A secure version that is protected from SQL injection
+
+## How It Will Work
+- Add a switch called SECURE_MODE that is either True or False
+- If it’s False, the app will run insecure code using raw SQL strings
+- If it’s True, the app will run safe code using SQLAlchemy’s filter_by
+
+## Tasks
+- Add SECURE_MODE at the top of the app
+- Change the login route to check if SECURE_MODE is True or False
+- If False: use raw SQL to check username and password
+- If True: use filter_by to check login
+- Test both modes by trying to log in normally and by using a SQL injection input like:
+  - username: anything
+  - password: ' OR '1'='1
+
+## Notes
+I will try writing both versions and test how the injection works when the app is in vulnerable mode.

--- a/vulnerabilities/toggle_system_plan.md
+++ b/vulnerabilities/toggle_system_plan.md
@@ -1,0 +1,21 @@
+# Toggle System Plan
+
+## Purpose
+Allow the web app to run in either secure or vulnerable mode by switching one variable in the backend.
+
+## Toggle Variable
+SECURE_MODE = True or False
+
+## Where It Will Go
+- At the top of app.py
+- Used in the login() route to choose between secure and insecure login logic
+
+## What It Affects
+- The login logic for SQL Injection demo
+- Later: probably for other routes
+
+## Future Plans
+We can eventually:
+- Read the toggle value from an environment variable
+- Add a dropdown in the UI to switch modes
+- Display which mode is active somewhere on the dashboard


### PR DESCRIPTION
This PR adds a working toggle system to switch between secure and vulnerable login logic.

- Secure mode uses SQLAlchemy's filter_by (safe)
- Vulnerable mode uses raw SQL with string formatting (intentionally unsafe)
- Flash messages indicate the current mode
- Injection confirmed using payload: `' OR '1'='1`

Tested both secure and vulnerable modes locally.
This supports the SQL Injection demonstration in our security phase and can be included in Progress Report 1.

Open for review. No merge yet unless the team agrees.